### PR TITLE
Update with new key for ROS apt repository

### DIFF
--- a/ROS/Dockerfile
+++ b/ROS/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -q -y \
     lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
 
 RUN apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
The key has changed for the ROS repository making the build fail. 
Updating with the new key gave a successful build.
For more details see this link:
https://discourse.ros.org/t/new-gpg-keys-deployed-for-packages-ros-org/9454